### PR TITLE
Add doc_link to Lessons

### DIFF
--- a/.dangerfile/policy_parser.rb
+++ b/.dangerfile/policy_parser.rb
@@ -1,7 +1,7 @@
 class PolicyParser
   DEFINITION_REGEX = /^[[:blank:]]*define[[:blank:]]*([\w_\.]+)[[:blank:]]*\([@$\w _,]*\)[[:blank:]]*.*do/.freeze
 
-  attr_reader :parsed_info,  :parsed_category, :parsed_name, :parsed_severity, :parsed_long_description, :parsed_short_description, :parsed_default_frequency
+  attr_reader :parsed_info, :parsed_category, :parsed_name, :parsed_severity, :parsed_doc_link, :parsed_long_description, :parsed_short_description, :parsed_default_frequency
 
   def parse(file)
     source = File.read(file)
@@ -26,6 +26,10 @@ class PolicyParser
 
   def severity(severity)
     @parsed_severity = severity
+  end
+
+  def doc_link(doc_link)
+    @parsed_doc_link = doc_link
   end
 
   def long_description(long_description)

--- a/exercises/01_summation/solution/summation.pt
+++ b/exercises/01_summation/solution/summation.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Sum of Two Numbers"
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/exercises/01_summation"
 category "Tutorial"
 severity "low"
 default_frequency "weekly"

--- a/exercises/02_tutorial_templates/solution/tutorial_templates.pt
+++ b/exercises/02_tutorial_templates/solution/tutorial_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all tutorial policy templates."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/exercises/02_tutorial_templates"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/exercises/03_employees/solution/employees.pt
+++ b/exercises/03_employees/solution/employees.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all employees, their teams, their departments, and their department heads."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/exercises/03_employees"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/exercises/04_departments/solution/departments.pt
+++ b/exercises/04_departments/solution/departments.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all departments, including employee count and budgets."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/exercises/04_departments"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/exercises/05_employees_table/solution/employees_table.pt
+++ b/exercises/05_employees_table/solution/employees_table.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all employees, their teams, their departments, and their department heads."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/exercises/05_employees_table"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/02_hello_world/README.md
+++ b/lessons/02_hello_world/README.md
@@ -18,6 +18,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Hello World"
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/02_hello_world"
 category "Tutorial"
 severity "low"
 default_frequency "weekly"
@@ -33,6 +34,7 @@ To briefly go over what each of these defines:
 * `type` simply indicates that this is a policy template and should always be set to "policy"
 * `short_description` is a brief description of what the policy template does. This will appear in Flexera One underneath the name when the policy template is uploaded.
 * `long_description` is defunct and should always be an empty string.
+* `doc_link` contains a link to documentation for the policy template. In this case, we're linking to this lesson.
 * `category` is the category of the policy template. In most cases, this will be something like "Cost", "Compliance", "Security", etc.
 * `severity` is the default severity level of any incidents raised by the policy template.
 * `default_frequency` is the default schedule for the policy template to execute.

--- a/lessons/02_hello_world/solution/hello_world.pt
+++ b/lessons/02_hello_world/solution/hello_world.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Hello World"
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/02_hello_world"
 category "Tutorial"
 severity "low"
 default_frequency "weekly"

--- a/lessons/03_parameters/solution/hello_world.pt
+++ b/lessons/03_parameters/solution/hello_world.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Hello World"
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/02_hello_world"
 category "Tutorial"
 severity "low"
 default_frequency "weekly"

--- a/lessons/04_escalations/solution/hello_world.pt
+++ b/lessons/04_escalations/solution/hello_world.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Hello World"
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/02_hello_world"
 category "Tutorial"
 severity "low"
 default_frequency "weekly"

--- a/lessons/05_fpt/solution/hello_world.pt
+++ b/lessons/05_fpt/solution/hello_world.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Hello World"
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/02_hello_world"
 category "Tutorial"
 severity "low"
 default_frequency "weekly"

--- a/lessons/06_api/README.md
+++ b/lessons/06_api/README.md
@@ -22,6 +22,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/06_api/solution/list_policy_templates.pt
+++ b/lessons/06_api/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/09_relational_data/solution/list_policy_templates.pt
+++ b/lessons/09_relational_data/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/10_debugging/solution/list_policy_templates_broken.pt
+++ b/lessons/10_debugging/solution/list_policy_templates_broken.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/10_debugging/solution/list_polity_templates_fixed.pt
+++ b/lessons/10_debugging/solution/list_polity_templates_fixed.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/11_request_scripts/solution/list_policy_templates.pt
+++ b/lessons/11_request_scripts/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/12_iterating/solution/list_policy_templates.pt
+++ b/lessons/12_iterating/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/14_misc/solution/list_policy_templates.pt
+++ b/lessons/14_misc/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/15_best_practices/solution/list_policy_templates.pt
+++ b/lessons/15_best_practices/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/16_xml/solution/list_policy_templates.pt
+++ b/lessons/16_xml/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/17_local_js/solution/list_policy_templates.pt
+++ b/lessons/17_local_js/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"

--- a/lessons/18_go_template/solution/list_policy_templates.pt
+++ b/lessons/18_go_template/solution/list_policy_templates.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Lists all policy templates uploaded to the Flexera organization."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_engine_training/tree/main/lessons/06_api"
 severity "low"
 category "Tutorial"
 default_frequency "weekly"


### PR DESCRIPTION
## Description

Adds doc_link metadata field to example policy templates and to lessons.
