### PR TITLE
Readme Updates - Rosetta, Step Ordering, Token URL includes unicode characters

### DIFF
--- a/setup/linux/README.md
+++ b/setup/linux/README.md
@@ -140,7 +140,7 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
   * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
   * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
 * **Client Authentication Method**: Token
-* **Token**: The API token you generated in Step 6.
+* **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.
 * **Scopes**: Leave blank.
 * **Provider**: flexera

--- a/setup/linux/README.md
+++ b/setup/linux/README.md
@@ -136,9 +136,9 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
 * **Credential Description**: Can be any arbitrary value. Describe the credential here for anyone else that might need to know what it is used for.
 * **Grant Type**: Refresh Token
 * **Token URL**: Depends on the region.
-  * **North America**: https:&#8203;\/\/login\.flexera\.com\/oidc\/token
-  * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
-  * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
+  * **North America**: `https://login.flexera.com/oidc/token`
+  * **Europe**: `https://login.flexera.eu/oidc/token`
+  * **APAC**: `https://login.flexera.au/oidc/token`
 * **Client Authentication Method**: Token
 * **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.

--- a/setup/linux/README.md
+++ b/setup/linux/README.md
@@ -48,13 +48,34 @@ To install VSCode, please follow the instructions on the [VSCode website](https:
 
 ## Step 6: fpt
 
-fpt is Flexera's native policy template development and testing tool. Run the following commands to download fpt and configure bash to add it to your PATH. Note that the below assumes you have access to the `wget` command line tool and are using bash; this should be the case for most Linux distributions.
+fpt is Flexera's native policy template development and testing tool.
+You can download the latest version of fpt for your platform from the releases page at [FTP releases on github.com](https://github.com/flexera-public/policy_sdk/releases).
 
-```bash
-wget https://binaries.rightscale.com/rsbin/fpt/v1.5.0/fpt-linux-amd64.tgz -O ~/fpt-linux-amd64.tgz
+Flexera provides AMD64 and ARM binaries. First, check your system architecture to determine which file to download:
 
-tar -xzvf ~/fpt-linux-amd64.tgz -C ~/
+```zsh
+uname -a
+```
 
+Based on the output, download the appropriate file from the GitHub releases page and then extract it:
+
+**For AMD64/x86_64 systems (most common):**
+
+```zsh
+# Download fpt-linux-amd64-[version].tgz from GitHub releases, then:
+tar -xzvf ~/fpt-linux-amd64-[version].tgz -C ~/
+```
+
+**For ARM64/aarch64 systems:**
+
+```zsh
+# Download fpt-linux-arm64-[version].tgz from GitHub releases, then:
+tar -xzvf ~/fpt-linux-arm64-[version].tgz -C ~/
+```
+
+After extracting the appropriate file, configure bash to add fpt to your PATH:
+
+```zsh
 echo 'export PATH=$PATH:$HOME/fpt' >> ~/.bashrc
 
 source ~/.bashrc
@@ -64,7 +85,7 @@ Once you've completed the installation steps above, you can verify that fpt is i
 
 ```bash
 > fpt -v
-fpt v1.5.0 - 2022-04-27 21:17:14 - 4a0a2e0052c9081144087448231e8b6fb6306906
+fpt v1.7.0 - 2025-09-03 23:30:54 - 3d7bff671883382ccce950bb404fc3095a26c752
 ```
 
 Note: The version number you see may be higher than the above if fpt has been updated since these lessons were created.

--- a/setup/macos/README.md
+++ b/setup/macos/README.md
@@ -64,6 +64,11 @@ echo 'export PATH=$PATH:$HOME/fpt' >> ~/.zshrc
 source ~/.zshrc
 ```
 
+For Apple Silicon MacOS, install Apple's rosetta2 compatibility layer to use fpt's amd64 binary.
+```sh
+if [[ "$(uname -m)" == "arm64" ]]; then /usr/sbin/softwareupdate --install-rosetta --agree-to-license; fi
+```
+
 Once you've completed the installation steps below, you can verify that fpt is installed with the `fpt -v` command, like so:
 
 ```zsh

--- a/setup/macos/README.md
+++ b/setup/macos/README.md
@@ -145,9 +145,9 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
 * **Credential Description**: Can be any arbitrary value. Describe the credential here for anyone else that might need to know what it is used for.
 * **Grant Type**: Refresh Token
 * **Token URL**: Depends on the region.
-  * **North America**: https:&#8203;\/\/login\.flexera\.com\/oidc\/token
-  * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
-  * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
+  * **North America**: `https://login.flexera.com/oidc/token`
+  * **Europe**: `https://login.flexera.eu/oidc/token`
+  * **APAC**: `https://login.flexera.au/oidc/token`
 * **Client Authentication Method**: Token
 * **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.

--- a/setup/macos/README.md
+++ b/setup/macos/README.md
@@ -149,7 +149,7 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
   * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
   * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
 * **Client Authentication Method**: Token
-* **Token**: The API token you generated in Step 6.
+* **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.
 * **Scopes**: Leave blank.
 * **Provider**: flexera

--- a/setup/macos/README.md
+++ b/setup/macos/README.md
@@ -50,30 +50,48 @@ In order to develop policy templates, you will need a text editor. Our recommend
 
 To install VSCode, please follow the instructions on the [VSCode website](https://code.visualstudio.com/download) for your specific operating system.
 
-## Step 7: fpt
+## Step 6: fpt
 
-fpt is Flexera's native policy template development and testing tool. Run the following commands to download fpt and configure bash to add it to your PATH.
+fpt is Flexera's native policy template development and testing tool.
+You can download the latest version of fpt for your platform from the releases page at [FTP releases on github.com](https://github.com/flexera-public/policy_sdk/releases).
+
+Flexera provides AMD64 and ARM binaries. First, check your system architecture to determine which file to download:
 
 ```zsh
-wget https://binaries.rightscale.com/rsbin/fpt/v1.5.0/fpt-darwin-amd64.tgz -O ~/fpt-darwin-amd64.tgz
+uname -a
+```
 
-tar -xzvf ~/fpt-linux-amd64.tgz -C ~/
+Based on the output, download the appropriate file from the GitHub releases page and then extract it:
 
+**For AMD64/x86_64 systems (most common):**
+
+```zsh
+# Download fpt-linux-amd64-[version].tgz from GitHub releases, then:
+tar -xzvf ~/fpt-darwin-amd64-[version].tgz -C ~/
+```
+
+**For ARM64/aarch64 systems:**
+
+```zsh
+# Download fpt-linux-arm64-[version].tgz from GitHub releases, then:
+tar -xzvf ~/fpt-darwin-arm64-[version].tgz -C ~/
+# Allow fpt in MacOS gatekeeper
+xattr -dr com.apple.quarantine fpt/fpt
+```
+
+After extracting the appropriate file, configure zsh to add fpt to your PATH:
+
+```zsh
 echo 'export PATH=$PATH:$HOME/fpt' >> ~/.zshrc
 
 source ~/.zshrc
 ```
 
-For Apple Silicon MacOS, install Apple's rosetta2 compatibility layer to use fpt's amd64 binary.
-```sh
-if [[ "$(uname -m)" == "arm64" ]]; then /usr/sbin/softwareupdate --install-rosetta --agree-to-license; fi
-```
-
-Once you've completed the installation steps below, you can verify that fpt is installed with the `fpt -v` command, like so:
+Once you've completed the installation steps above, you can verify that fpt is installed with the `fpt -v` command, like so:
 
 ```zsh
 > fpt -v
-fpt v1.5.0 - 2022-04-27 21:17:14 - 4a0a2e0052c9081144087448231e8b6fb6306906
+fpt v1.7.0 - 2025-09-03 23:30:54 - 3d7bff671883382ccce950bb404fc3095a26c752
 ```
 
 Note: The version number you see may be higher than the above if fpt has been updated since these lessons were created.

--- a/setup/windows_powershell/README.md
+++ b/setup/windows_powershell/README.md
@@ -57,15 +57,34 @@ To install VSCode, please follow the instructions on the [VSCode website](https:
 
 ## Step 6: fpt
 
-fpt is Flexera's native policy template development and testing tool. Installation will vary depending on your operating system and command line configuration.
+fpt is Flexera's native policy template development and testing tool.
+You can download the latest version of fpt for your platform from the releases page at [FTP releases on github.com](https://github.com/flexera-public/policy_sdk/releases).
 
-Run the following commands to download fpt and configure PowerShell to add it to your PATH. We recommended that you restart your PowerShell terminal after doing this to ensure the new configurations are in effect.
+Flexera provides AMD64 and ARM binaries. First, check your system architecture to determine which file to download:
 
 ```powershell
-Invoke-WebRequest -Uri "https://binaries.rightscale.com/rsbin/fpt/v1.5.0/fpt-windows-amd64.zip" -OutFile "$env:USERPROFILE\fpt-windows-amd64.zip"
+$env:PROCESSOR_ARCHITECTURE
+```
 
-Expand-Archive -Path "$env:USERPROFILE\fpt-windows-amd64.zip" -DestinationPath "$env:USERPROFILE"
+Based on the output, download the appropriate file from the GitHub releases page and then extract it:
 
+**For AMD64/x64 systems (most common):**
+
+```powershell
+# Download fpt-windows-amd64-[version].zip from GitHub releases, then:
+Expand-Archive -Path "$env:USERPROFILE\fpt-windows-amd64-[version].zip" -DestinationPath "$env:USERPROFILE"
+```
+
+**For ARM64 systems:**
+
+```powershell
+# Download fpt-windows-arm64-[version].zip from GitHub releases, then:
+Expand-Archive -Path "$env:USERPROFILE\fpt-windows-arm64-[version].zip" -DestinationPath "$env:USERPROFILE"
+```
+
+After extracting the appropriate file, configure PowerShell to add fpt to your PATH. We recommended that you restart your PowerShell terminal after doing this to ensure the new configurations are in effect:
+
+```powershell
 [System.Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:USERPROFILE\fpt", [System.EnvironmentVariableTarget]::User)
 ```
 
@@ -73,7 +92,7 @@ Once you've completed the installation steps above, you can verify that fpt is i
 
 ```powershell
 > fpt -v
-fpt v1.5.0 - 2022-04-27 21:17:14 - 4a0a2e0052c9081144087448231e8b6fb6306906
+fpt v1.7.0 - 2025-09-03 23:30:54 - 3d7bff671883382ccce950bb404fc3095a26c752
 ```
 
 Note: The version number you see may be higher than the above if fpt has been updated since these lessons were created.

--- a/setup/windows_powershell/README.md
+++ b/setup/windows_powershell/README.md
@@ -145,9 +145,9 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
 * **Credential Description**: Can be any arbitrary value. Describe the credential here for anyone else that might need to know what it is used for.
 * **Grant Type**: Refresh Token
 * **Token URL**: Depends on the region.
-  * **North America**: https:&#8203;\/\/login\.flexera\.com\/oidc\/token
-  * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
-  * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
+  * **North America**: `https://login.flexera.com/oidc/token`
+  * **Europe**: `https://login.flexera.eu/oidc/token`
+  * **APAC**: `https://login.flexera.au/oidc/token`
 * **Client Authentication Method**: Token
 * **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.

--- a/setup/windows_powershell/README.md
+++ b/setup/windows_powershell/README.md
@@ -149,7 +149,7 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
   * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
   * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
 * **Client Authentication Method**: Token
-* **Token**: The API token you generated in Step 6.
+* **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.
 * **Scopes**: Leave blank.
 * **Provider**: flexera

--- a/setup/windows_wsl2/README.md
+++ b/setup/windows_wsl2/README.md
@@ -140,7 +140,7 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
   * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
   * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
 * **Client Authentication Method**: Token
-* **Token**: The API token you generated in Step 6.
+* **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.
 * **Scopes**: Leave blank.
 * **Provider**: flexera

--- a/setup/windows_wsl2/README.md
+++ b/setup/windows_wsl2/README.md
@@ -136,9 +136,9 @@ In order to make calls to the Flexera API via the policy engine, we'll need to c
 * **Credential Description**: Can be any arbitrary value. Describe the credential here for anyone else that might need to know what it is used for.
 * **Grant Type**: Refresh Token
 * **Token URL**: Depends on the region.
-  * **North America**: https:&#8203;\/\/login\.flexera\.com\/oidc\/token
-  * **Europe**: https:&#8203;\/\/login\.flexera\.eu\/oidc\/token
-  * **APAC**: https:&#8203;\/\/login\.flexera\.au\/oidc\/token
+  * **North America**: `https://login.flexera.com/oidc/token`
+  * **Europe**: `https://login.flexera.eu/oidc/token`
+  * **APAC**: `https://login.flexera.au/oidc/token`
 * **Client Authentication Method**: Token
 * **Token**: the API Refresh token you generated in step 7.
 * **Additional Headers**: Leave blank.

--- a/setup/windows_wsl2/README.md
+++ b/setup/windows_wsl2/README.md
@@ -48,13 +48,34 @@ To install VSCode, please follow the instructions on the [VSCode website](https:
 
 ## Step 6: fpt
 
-fpt is Flexera's native policy template development and testing tool. Run the following commands to download fpt and configure bash to add it to your PATH. Note that the below assumes you have access to the `wget` command line tool and are using bash; this should be the case for most Linux distributions.
+fpt is Flexera's native policy template development and testing tool.
+You can download the latest version of fpt for your platform from the releases page at [FTP releases on github.com](https://github.com/flexera-public/policy_sdk/releases).
 
-```bash
-wget https://binaries.rightscale.com/rsbin/fpt/v1.5.0/fpt-linux-amd64.tgz -O ~/fpt-linux-amd64.tgz
+Flexera provides AMD64 and ARM binaries. First, check your system architecture to determine which file to download:
 
-tar -xzvf ~/fpt-linux-amd64.tgz -C ~/
+```zsh
+uname -a
+```
 
+Based on the output, download the appropriate file from the GitHub releases page and then extract it:
+
+**For AMD64/x86_64 systems (most common):**
+
+```zsh
+# Download fpt-linux-amd64-[version].tgz from GitHub releases, then:
+tar -xzvf ~/fpt-linux-amd64-[version].tgz -C ~/
+```
+
+**For ARM64/aarch64 systems:**
+
+```zsh
+# Download fpt-linux-arm64-[version].tgz from GitHub releases, then:
+tar -xzvf ~/fpt-linux-arm64-[version].tgz -C ~/
+```
+
+After extracting the appropriate file, configure bash to add fpt to your PATH:
+
+```zsh
 echo 'export PATH=$PATH:$HOME/fpt' >> ~/.bashrc
 
 source ~/.bashrc
@@ -64,7 +85,7 @@ Once you've completed the installation steps above, you can verify that fpt is i
 
 ```bash
 > fpt -v
-fpt v1.5.0 - 2022-04-27 21:17:14 - 4a0a2e0052c9081144087448231e8b6fb6306906
+fpt v1.7.0 - 2025-09-03 23:30:54 - 3d7bff671883382ccce950bb404fc3095a26c752
 ```
 
 Note: The version number you see may be higher than the above if fpt has been updated since these lessons were created.


### PR DESCRIPTION
## Description

Solves #39  

- Add rosetta compatibility layer command for use with FTP that is currently bundled as amd platform type only. 
- Correct readme step ordering that (step 9 referred to API key gen on step 6, which is now on step 7)
- Wrap Token URLs in the Flexera One interface in markdown backticks and remove unicode characters, as when included these caused key creation error on FO key creation with that refresh token 

